### PR TITLE
toArrayParams fails if there are no params

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ var createCompiler = function(config) {
   function toArrayParams(tree, params) {
     var arr = [];
     if (tree.length == 1)
-      return [query, []];
+      return [tree[0], []];
     var tokens = tree[1];
     for (var i=0; i < tokens.length; ++i)
       arr.push(params[tokens[i]]);


### PR DESCRIPTION
A small fix for this situation.
