### PR TITLE
Add support for placeholders that begin with a `_`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 // based on code from Brian White @mscdex mariasql library - https://github.com/mscdex/node-mariasql/blob/master/lib/Client.js#L272-L332
 // License: https://github.com/mscdex/node-mariasql/blob/master/LICENSE
 
-var RE_PARAM = /(?:\?)|(?::(\d+|(?:[a-zA-Z][a-zA-Z0-9_]*)))/g,
+var RE_PARAM = /(?:\?)|(?::(\d+|(?:[a-zA-Z_][a-zA-Z0-9_]*)))/g,
     DQUOTE = 34,
     SQUOTE = 39,
     BSLASH = 92;

--- a/test/example.md
+++ b/test/example.md
@@ -60,6 +60,15 @@ it should replace ::name style placeholders with `??` placeholders
     .should.eql([ 'normal placeholder ? and double semicolon ?? test', [ 'test1', 'test2' ] ]);
 ```
 
+it should replace :name style placeholders that start with `_`
+
+```js
+  var compile = require('..')();
+
+  query = 'normal placeholder :p1 and underscore-leading placeholder :_p2 test';
+  compile(query, {p1: 'test1', _p2: 'test2'})
+    .should.eql([ 'normal placeholder ? and underscore-leading placeholder ? test', [ 'test1', 'test2' ] ]);
+```
 
 # postgres-style toNumbered conversion
 


### PR DESCRIPTION
This adds support for placeholder names that begin with an underscore (`_`)

* Adds test demonstrating feature