### PR TITLE
Convert CI to GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [6.x, 8.x, 10.x, 12.x, 14.x, 16.x, 18.x]
+
+    name: Node.js ${{ matrix.node-version }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install npm dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - "6"
-  - "8"
-  - "10"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM](https://nodei.co/npm/named-placeholders.png?downloads=true&stars=true)](https://nodei.co/npm/named-placeholders/)
 
-[![Build Status](https://secure.travis-ci.org/sidorares/named-placeholders.png)](http://travis-ci.org/sidorares/named-placeholders)
+[![CI](https://github.com/mysqljs/named-placeholders/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/mysqljs/named-placeholders/actions/workflows/ci.yml)
 
 # named-placeholders
 


### PR DESCRIPTION
PR converts the CI from using travis-ci.org to GH actions. Currently, since the CI is pointed at travis-ci.org, it won't run at all, and there's not much point going to travis-ci.com and deal with the limit on test credits or whatever, given that the service is largely dying.

See https://github.com/MasterOdin/named-placeholders/pull/1 for this successfully running on my fork.