### PR TITLE
Bump lru-cache dependency to ^7.14.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [6.x, 8.x, 10.x, 12.x, 14.x, 16.x, 18.x]
+        node-version: [12.x, 14.x, 16.x, 18.x]
 
     name: Node.js ${{ matrix.node-version }}
 

--- a/index.js
+++ b/index.js
@@ -65,8 +65,6 @@ function parse(query) {
   return [query];
 };
 
-const EMPTY_LRU_FN = (key, value) => {};
-
 function createCompiler(config) {
   if (!config)
   config = {};
@@ -82,7 +80,7 @@ function createCompiler(config) {
     cache = config.cache;
   }
   if (config.cache !== false && !cache) {
-    cache = require('lru-cache')({ max: ncache, dispose: EMPTY_LRU_FN });
+    cache = new (require('lru-cache'))({ max: ncache });
   }
 
   function toArrayParams(tree, params) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "placeholders"
   ],
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=12.0.0"
   },
   "author": "Andrey Sidorov <sidorares@yandex.com>",
   "files": [],
@@ -27,6 +27,6 @@
     "should": "^13.2.3"
   },
   "dependencies": {
-    "lru-cache": "^4.1.3"
+    "lru-cache": "^7.14.1"
   }
 }

--- a/test/example.js
+++ b/test/example.js
@@ -5,7 +5,6 @@ const assert = require('assert');
 require('should');
 
 describe('given input query with named parameters', () => {
-
   it('should build corresponding query with `?` placeholders and fill array of parameters from input object', () => {
     let query = 'Select users.json,EXISTS(Select 1 from moderators where moderators.id = :id) as is_moderator from users where users.id = :id and users.status = :status and users.complete_status = :complete_status';
 
@@ -33,38 +32,44 @@ describe('given input query with named parameters', () => {
         compile(query);
       },
       /Named query contains placeholders, but parameters object is undefined/
-      );
-    });
-
-    it('should replace ::name style placeholders with `??` placeholders', () => {
-
-      let query = 'normal placeholder :p1 and double semicolon ::p2';
-      compile(query, {p1: 'test1', p2: 'test2'})
-      .should.eql([ 'normal placeholder ? and double semicolon ??', [ 'test1', 'test2' ] ]);
-
-      query = 'normal placeholder ::p1 and double semicolon :p2';
-      compile(query, {p1: 'test1', p2: 'test2'})
-      .should.eql([ 'normal placeholder ?? and double semicolon ?', [ 'test1', 'test2' ] ]);
-
-      query = 'normal placeholder ::p2 and double semicolon :p1';
-      compile(query, {p1: 'test1', p2: 'test2'})
-      .should.eql([ 'normal placeholder ?? and double semicolon ?', [ 'test2', 'test1' ] ]);
-
-      query = 'normal placeholder :p1 and double semicolon ::p2 test';
-      compile(query, {p1: 'test1', p2: 'test2'})
-      .should.eql([ 'normal placeholder ? and double semicolon ?? test', [ 'test1', 'test2' ] ]);
-    });
+    );
   });
 
-  describe('postgres-style toNumbered conversion', () => {
-    it('basic test', () => {
-      const toNumbered = require('..').toNumbered;
-      const query = 'SELECT usr.p_pause_stop_track(:doc_dtl_id, :plan_id, :wc_id, 20, :time_from)';
-      toNumbered(query, {
-        doc_dtl_id: 123,
-        time_from: 345,
-        plan_id: 456,
-        wc_id: 678
-      }).should.eql([ 'SELECT usr.p_pause_stop_track($1, $2, $3, 20, $4)', [ 123, 456, 678, 345 ]]);
-    });
+  it('should replace ::name style placeholders with `??` placeholders', () => {
+    let query = 'normal placeholder :p1 and double semicolon ::p2';
+    compile(query, {p1: 'test1', p2: 'test2'})
+    .should.eql([ 'normal placeholder ? and double semicolon ??', [ 'test1', 'test2' ] ]);
+
+    query = 'normal placeholder ::p1 and double semicolon :p2';
+    compile(query, {p1: 'test1', p2: 'test2'})
+    .should.eql([ 'normal placeholder ?? and double semicolon ?', [ 'test1', 'test2' ] ]);
+
+    query = 'normal placeholder ::p2 and double semicolon :p1';
+    compile(query, {p1: 'test1', p2: 'test2'})
+    .should.eql([ 'normal placeholder ?? and double semicolon ?', [ 'test2', 'test1' ] ]);
+
+    query = 'normal placeholder :p1 and double semicolon ::p2 test';
+    compile(query, {p1: 'test1', p2: 'test2'})
+    .should.eql([ 'normal placeholder ? and double semicolon ?? test', [ 'test1', 'test2' ] ]);
   });
+
+  it('compiles the query the same twice', () => {
+    const query = 'SELECT * FROM foo WHERE id = :id';
+    const expected = [ 'SELECT * FROM foo WHERE id = ?', [ 123 ] ];
+    compile(query, { id: 123 }).should.eql(expected);
+    compile(query, { id: 123 }).should.eql(expected);
+  });
+});
+
+describe('postgres-style toNumbered conversion', () => {
+  it('basic test', () => {
+    const toNumbered = require('..').toNumbered;
+    const query = 'SELECT usr.p_pause_stop_track(:doc_dtl_id, :plan_id, :wc_id, 20, :time_from)';
+    toNumbered(query, {
+      doc_dtl_id: 123,
+      time_from: 345,
+      plan_id: 456,
+      wc_id: 678
+    }).should.eql([ 'SELECT usr.p_pause_stop_track($1, $2, $3, 20, $4)', [ 123, 456, 678, 345 ]]);
+  });
+});


### PR DESCRIPTION
PR bumps the [`lru-cache`](https://www.npmjs.com/package/lru-cache) to its latest version (which matches the version string used for `mysql2`).  I had considered lowering the version, but given https://github.com/isaacs/node-lru-cache/issues/257 which was fixed in the latest release, probably not worth allowing older versions.

I also added a test that goes through the `cache.get` code path as no existing test exercised it to help validate that LRU is (hopefully) working as expected, though `cache.get(query)` could just always return `undefined` or whatever.

I also updated the minimum version of this package and what versions of Node are tested against as `lru-cache@^7` as a minimal supported node version of `12`.

Finally, I ended up changing indentation of some amount of the test file as everything after the `should throw error when query contains placeholders but parameters object not passed` was indented when it shouldn't have been. Beyond the new test addition, all other changes in that file are just whitespace related.