### PR TITLE
ci!: migrate to built in node test runner and remove mocha dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "named-placeholders",
+  "version": "1.1.3",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "named-placeholders",
+      "version": "1.1.3",
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "^8.0.5"
+      },
+      "devDependencies": {},
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
+      "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==",
+      "engines": {
+        "node": ">=16.14"
+      }
+    }
+  }
+}

--- a/test/example.js
+++ b/test/example.js
@@ -1,26 +1,28 @@
 'use strict';
 
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
 const compile = require('..')();
-const assert = require('assert');
-require('should');
 
 describe('given input query with named parameters', () => {
   it('should build corresponding query with `?` placeholders and fill array of parameters from input object', () => {
     let query = 'Select users.json,EXISTS(Select 1 from moderators where moderators.id = :id) as is_moderator from users where users.id = :id and users.status = :status and users.complete_status = :complete_status';
 
-    compile(query, {id: 123, status: 'Yes!', complete_status: 'No!'})
-    .should.eql([ 'Select users.json,EXISTS(Select 1 from moderators where moderators.id = ?) as is_moderator from users where users.id = ? and users.status = ? and users.complete_status = ?',
+    const result1 = compile(query, {id: 123, status: 'Yes!', complete_status: 'No!'});
+
+    assert.deepEqual(result1, [ 'Select users.json,EXISTS(Select 1 from moderators where moderators.id = ?) as is_moderator from users where users.id = ? and users.status = ? and users.complete_status = ?',
     [ 123, 123, 'Yes!', 'No!' ] ]);
 
     // from https://github.com/sidorares/named-placeholders/issues/2
     query = 'SELECT * FROM items WHERE id = :id AND deleted = "0000-00-00 00:00:00"';
-    compile(query, { id: Number(123) })
-    .should.eql([ 'SELECT * FROM items WHERE id = ? AND deleted = "0000-00-00 00:00:00"',
+    const result2 = compile(query, { id: Number(123) })
+    assert.deepEqual(result2, [ 'SELECT * FROM items WHERE id = ? AND deleted = "0000-00-00 00:00:00"',
     [ 123 ] ]);
 
     query = 'SELECT * FROM items WHERE deleted = "0000-00-00 00:00:00" AND id = :id';
-    compile(query, { id: Number(123) })
-    .should.eql([ 'SELECT * FROM items WHERE deleted = "0000-00-00 00:00:00" AND id = ?',
+    const result3 = compile(query, { id: Number(123) })
+    assert.deepEqual(result3, [ 'SELECT * FROM items WHERE deleted = "0000-00-00 00:00:00" AND id = ?',
     [ 123 ] ]);
   });
 
@@ -37,27 +39,27 @@ describe('given input query with named parameters', () => {
 
   it('should replace ::name style placeholders with `??` placeholders', () => {
     let query = 'normal placeholder :p1 and double semicolon ::p2';
-    compile(query, {p1: 'test1', p2: 'test2'})
-    .should.eql([ 'normal placeholder ? and double semicolon ??', [ 'test1', 'test2' ] ]);
+    assert.deepEqual(compile(query, {p1: 'test1', p2: 'test2'}),
+      [ 'normal placeholder ? and double semicolon ??', [ 'test1', 'test2' ] ]);
 
     query = 'normal placeholder ::p1 and double semicolon :p2';
-    compile(query, {p1: 'test1', p2: 'test2'})
-    .should.eql([ 'normal placeholder ?? and double semicolon ?', [ 'test1', 'test2' ] ]);
+    assert.deepEqual(compile(query, {p1: 'test1', p2: 'test2'}),
+      [ 'normal placeholder ?? and double semicolon ?', [ 'test1', 'test2' ] ]);
 
     query = 'normal placeholder ::p2 and double semicolon :p1';
-    compile(query, {p1: 'test1', p2: 'test2'})
-    .should.eql([ 'normal placeholder ?? and double semicolon ?', [ 'test2', 'test1' ] ]);
+    assert.deepEqual(compile(query, {p1: 'test1', p2: 'test2'}),
+      [ 'normal placeholder ?? and double semicolon ?', [ 'test2', 'test1' ] ]);
 
     query = 'normal placeholder :p1 and double semicolon ::p2 test';
-    compile(query, {p1: 'test1', p2: 'test2'})
-    .should.eql([ 'normal placeholder ? and double semicolon ?? test', [ 'test1', 'test2' ] ]);
+    assert.deepEqual(compile(query, {p1: 'test1', p2: 'test2'}),
+      [ 'normal placeholder ? and double semicolon ?? test', [ 'test1', 'test2' ] ]);
   });
 
   it('compiles the query the same twice', () => {
     const query = 'SELECT * FROM foo WHERE id = :id';
     const expected = [ 'SELECT * FROM foo WHERE id = ?', [ 123 ] ];
-    compile(query, { id: 123 }).should.eql(expected);
-    compile(query, { id: 123 }).should.eql(expected);
+    assert.deepEqual(compile(query, { id: 123 }), expected);
+    assert.deepEqual(compile(query, { id: 123 }), expected);
   });
 });
 
@@ -65,11 +67,11 @@ describe('postgres-style toNumbered conversion', () => {
   it('basic test', () => {
     const toNumbered = require('..').toNumbered;
     const query = 'SELECT usr.p_pause_stop_track(:doc_dtl_id, :plan_id, :wc_id, 20, :time_from)';
-    toNumbered(query, {
+    assert.deepEqual(toNumbered(query, {
       doc_dtl_id: 123,
       time_from: 345,
       plan_id: 456,
       wc_id: 678
-    }).should.eql([ 'SELECT usr.p_pause_stop_track($1, $2, $3, 20, $4)', [ 123, 456, 678, 345 ]]);
+    }), [ 'SELECT usr.p_pause_stop_track($1, $2, $3, 20, $4)', [ 123, 456, 678, 345 ]]);
   });
 });


### PR DESCRIPTION
note: bumping lru-cache to 8x is potentially a major version bump due to changed node engine requirement ( see https://github.com/sidorares/node-mysql2/issues/1953 )