### PR TITLE
fix: resolve dependency conflicts

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ function createCompiler(config) {
     cache = config.cache;
   }
   if (config.cache !== false && !cache) {
-    cache = new (require('lru-cache'))({ max: ncache });
+    cache = (require('lru.min').createLRU)({ max: ncache });
   }
 
   function toArrayParams(tree, params) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,25 @@
       "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
-        "lru-cache": "^8.0.5"
+        "lru.min": "^1.1.0"
       },
       "engines": {
         "node": ">=12.0.0"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
-      "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==",
-      "license": "ISC",
+    "node_modules/lru.min": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.0.tgz",
+      "integrity": "sha512-86xXMB6DiuKrTqkE/lRL0drlNh568awttBPJ7D66fzDHpy6NC5r3N+Ly/lKCS2zjmeGyvFDx670z0cD0PVBwGA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=16.14"
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "lru.min": "^1.1.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/lru.min": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "lru-cache": "^8.0.5"
       },
-      "devDependencies": {},
       "engines": {
         "node": ">=12.0.0"
       }
@@ -20,6 +19,7 @@
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
       "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==",
+      "license": "ISC",
       "engines": {
         "node": ">=16.14"
       }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   "files": [],
   "license": "MIT",
   "dependencies": {
-    "lru-cache": "^8.0.5"
+    "lru.min": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "sql named placeholders to unnamed compiler",
   "main": "index.js",
   "scripts": {
-    "test": "node --test test/**/*.js"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,7 @@
   "author": "Andrey Sidorov <sidorares@yandex.com>",
   "files": [],
   "license": "MIT",
-  "devDependencies": {
-    "mocha": "^5.2.0",
-    "should": "^13.2.3"
-  },
   "dependencies": {
-    "lru-cache": "^7.14.1"
+    "lru-cache": "^8.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "placeholders"
   ],
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=8.0.0"
   },
   "author": "Andrey Sidorov <sidorares@yandex.com>",
   "files": [],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "sql named placeholders to unnamed compiler",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "node --test test/**/*.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Sorry for the unsolicited _PR_. Please, feel free to close as well.

This _PR_ follows exactly the same purpose of https://github.com/sidorares/node-mysql2/pull/2988.

### Small chores

- I noticed that package.json and package-lock.json weren't synchronized, I just adjusted that.
- Same idea for test script to use **Node.js** test runner.

### Cache

This dependency change prevents conflicts for multiple major versions of the same package for the final user.

Also, it's interesting to note that even upgrading `lru-cache` to the same version for both `named-placeholders` and `mysql2`, this would still imply a premature breaking change in order to an outdated version of the `lru-cache` (`8.x` instead of `11.x`).

To use the latest `lru-cache`, it requires **Node.js** `v20.x.x` or higher.

---

> [!NOTE]
> This _PR_ doesn't depend on https://github.com/sidorares/node-mysql2/pull/2988 and vice versa. Each _PR_ acts individually.