### PR TITLE
fix: allow named parameters to start with underscore

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
   "assist": {
     "actions": {
       "source": {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 // based on code from Brian White @mscdex mariasql library - https://github.com/mscdex/node-mariasql/blob/master/lib/Client.js#L272-L332
 // License: https://github.com/mscdex/node-mariasql/blob/master/LICENSE
 
-const RE_PARAM = /(?:\?)|(?::(\d+|(?:[a-zA-Z][a-zA-Z0-9_]*)))/g,
+const RE_PARAM = /(?:\?)|(?::(\d+|(?:[a-zA-Z_][a-zA-Z0-9_]*)))/g,
   DQUOTE = 34,
   SQUOTE = 39,
   BSLASH = 92;

--- a/test/example.js
+++ b/test/example.js
@@ -113,6 +113,21 @@ describe('given input query with named parameters', () => {
     assert.strictEqual(result[1].length, 4, 'Should extract all 4 parameters');
     assert.deepEqual(result[1], [100, '2024-01-01', '2024-12-31', 'active']);
   });
+
+  it('should support parameters starting with underscore', () => {
+    // Parameters can start with underscore character
+    let query = 'SELECT * FROM users WHERE id = :_id AND role = :_role';
+    assert.deepEqual(compile(query, { _id: 123, _role: 'admin' }), [
+      'SELECT * FROM users WHERE id = ? AND role = ?',
+      [123, 'admin'],
+    ]);
+
+    query = 'SELECT * FROM users WHERE _internal_id = :_internal_id AND _status = :_status AND name = :_name';
+    assert.deepEqual(compile(query, { _internal_id: 456, _status: 'active', _name: 'John' }), [
+      'SELECT * FROM users WHERE _internal_id = ? AND _status = ? AND name = ?',
+      [456, 'active', 'John'],
+    ]);
+  });
 });
 
 describe('postgres-style toNumbered conversion', () => {

--- a/test/example.js
+++ b/test/example.js
@@ -115,7 +115,6 @@ describe('given input query with named parameters', () => {
   });
 
   it('should support parameters starting with underscore', () => {
-    // Parameters can start with underscore character
     let query = 'SELECT * FROM users WHERE id = :_id AND role = :_role';
     assert.deepEqual(compile(query, { _id: 123, _role: 'admin' }), [
       'SELECT * FROM users WHERE id = ? AND role = ?',

--- a/test/example.js
+++ b/test/example.js
@@ -122,11 +122,15 @@ describe('given input query with named parameters', () => {
       [123, 'admin'],
     ]);
 
-    query = 'SELECT * FROM users WHERE _internal_id = :_internal_id AND _status = :_status AND name = :_name';
-    assert.deepEqual(compile(query, { _internal_id: 456, _status: 'active', _name: 'John' }), [
-      'SELECT * FROM users WHERE _internal_id = ? AND _status = ? AND name = ?',
-      [456, 'active', 'John'],
-    ]);
+    query =
+      'SELECT * FROM users WHERE _internal_id = :_internal_id AND _status = :_status AND name = :_name';
+    assert.deepEqual(
+      compile(query, { _internal_id: 456, _status: 'active', _name: 'John' }),
+      [
+        'SELECT * FROM users WHERE _internal_id = ? AND _status = ? AND name = ?',
+        [456, 'active', 'John'],
+      ]
+    );
   });
 });
 


### PR DESCRIPTION
Updated RE_PARAM regex to support parameter names beginning with underscore (_), such as :_start, :_limit, :_offset, etc.

Previously, the regex pattern [a-zA-Z][a-zA-Z0-9_]* required the first character to be a letter. This prevented valid parameter names like :_start from being recognized.

Changed pattern to [a-zA-Z_][a-zA-Z0-9_]* to allow underscore as the first character, matching common SQL parameter naming conventions used by many database drivers and ORMs.

This change maintains backward compatibility while extending support for a wider range of valid parameter names.